### PR TITLE
Update dir-name and append text to config file

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,6 +8,6 @@ bundle install
 
 # Do any other automated setup that you need to do here
 
-mkdir ~/.lbp-print-cli
-echo "output_base='TODO:add/base/directory/here'" > ~/.lbp-print/config.rb
-echo "xslt_base='TODO:add/base/directory/here'" > ~/.lbp-print/config.rb
+mkdir ~/.lbp-print
+echo "output_base='TODO:add/base/directory/here'" >> ~/.lbp-print/config.rb
+echo "xslt_base='TODO:add/base/directory/here'" >> ~/.lbp-print/config.rb


### PR DESCRIPTION
The `>` truncates the file, which only leaves the last line in the
config.py file.

Currently the bin/setup file does not create a functioning configuration file.
1. The config dir (`~/.lbp-print-cli`) does not match the dir where the text is printed to (`~/.lbp-print/config.rb`
2. The config files is truncated, leaving only the last line in file (with `>` in stead of `>>`).

This should fix that.
