### PR TITLE
biggest change here is re-ordering of parameter priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The script also takes the following optional parameters:
 
 ```
 Options:
-  [--pdf-output=BOOLEAN]  # If this is given, the tex-file will be
+  [--pdf-output], [--no-pdf-output]  # If this is given, the tex-file will be
                                      # compiled with pdflatex.
                                      # Default: false
   [--output-parent=OUTPUT_PARENT]    # A directory name inside the `output_base`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Make sure you have LaTeX installed. For a Mac, we suggest installing MacTex
 To install the lbp-print cli from soucrce, follow these steps:
 
 Clone the repo
-    
+
     $ git clone https://github.com/lombardpress/lbp-print.git
 
 Enter the cloned repo
@@ -69,46 +69,48 @@ Once set up, you can invoke a transformation as follows:
 
 The script also takes the following optional parameters:
 
-``` 
+```
 Options:
-  [--pdf-output], [--no-pdf-output]  # If this is given, the tex-file will be 
+  [--pdf-output=BOOLEAN]  # If this is given, the tex-file will be
                                      # compiled with pdflatex.
-  [--output-parent=OUTPUT_PARENT]    # A directory name inside the `output_base` 
+                                     # Default: false
+  [--output-parent=OUTPUT_PARENT]    # A directory name inside the `output_base`
                                      # directory where the files will be put.
                                      # Default: examples
-  [--package=PACKAGE]                # The xslt package used for processing the 
-                                     # XML file. This package must be a 
+  [--package=PACKAGE]                # The xslt package used for processing the
+                                     # XML file. This package must be a
                                      # directory in the `xslt_base` directory.
                                      # Default: lbp-print-xslt
-  [--type=TYPE]                      # Indicate whether the processor converts a 
-                                     # file encoded according to the diplomatic 
+  [--type=TYPE]                      # Indicate whether the processor converts a
+                                     # file encoded according to the diplomatic
                                      # of critical LBP schema.
                                      # Default: critical
-  [--schema=SCHEMA]                  # Indicate which version of the LBP schema 
+  [--schema=SCHEMA]                  # Indicate which version of the LBP schema
                                      # the XML is compliant with.
                                      # Default: 1.0.0
 ```
 
-So a minimal real world example would be: 
+So a minimal real world example would be:
 
-    lbp-print tex penn_wdr-l4d18 
-    
+    lbp-print tex penn_wdr-l4d18
+
 An example with some of the optional parameters specified would look like this:
 
     lbp-print tex penn_wdr-l4d18 --output-parent=rothwellcommentary \\
-        --package=lbp-print-xslt --type=diplomatic --schema=0.0.0 
+        --package=lbp-print-xslt --type=diplomatic --schema=0.0.0
 
 The precedence of defining the optional parameters are the following:
-1. If the value can be indicated in the XML-file, get them. That is the case for:
+
+1. If the optional parameters have a value, use that.
+2. If the value can be indicated in the XML-file, get them. That is the case for:
   * `--type`, which is given in the `/TEI/text[1]/@type` attribute, i.e. the `@type` attribute of the first `text`-element (the highest level text element, sibling of `teiHeader`)
   * `--schema`, which is given as the numeric value after the last dash in `/TEI/teiHeader/encodingDesc[1]/schemaRef/@n`. So for example `lbp-critical-1.0.0` would yield `1.0.0`.
-2. If the value is given in the config file (~/.lbp-print/config.yaml), use that.
-3. If the optional parameters have a value, use that.
+3. If the value is given in the config file (~/.lbp-print/config.yaml), use that.
 4. If no optional parameter is given, use the default.
 
 The defaults in the config-file are set up as follows:
 
-    default_params: 
+    default_params:
       output_parent: examples
       package: lbp-print-xslt
       type: critical
@@ -129,4 +131,3 @@ Anyone can create custom xslt-latex packages that can be used by this command li
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/bin/lbp-print
+++ b/bin/lbp-print
@@ -22,11 +22,11 @@ module LbpPrintCLI
 			sourceversion=`git describe --tags --always`
 		end
 		desc "tex", "creates latex output"
-		option :pdf_output, :type => :boolean, :desc => "If this is given, the tex-file will be compiled with pdflatex."
-		option :output_parent, :default => "examples", :alias => "-o", :desc => "A directory name inside the `output_base` directory where the files will be put."
-		option :package, :default => "lbp-print-xslt", :alias => "-p", :desc => "The xslt package used for processing the XML file. This package must be a directory in the `xslt_base` directory."
-		option :type, :default => "critical", :alias => "-t", :desc => "Indicate whether the processor converts a file encoded according to the diplomatic of critical LBP schema."
-		option :schema, :default => "1.0.0", :alias => "-s", :desc => "Indicate which version of the LBP schema the XML is compliant with."
+		option :pdf_output, :type => :boolean, :alias => "-pdf", :desc => "If this is given, the tex-file will be compiled with pdflatex."
+		option :output_parent, :alias => "-o", :desc => "A directory name inside the `output_base` directory where the files will be put."
+		option :package, :alias => "-p", :desc => "The xslt package used for processing the XML file. This package must be a directory in the `xslt_base` directory."
+		option :type, :alias => "-t", :desc => "Indicate whether the processor converts a file encoded according to the diplomatic of critical LBP schema."
+		option :schema, :alias => "-s", :desc => "Indicate which version of the LBP schema the XML is compliant with."
 		def tex (filename)
 
 			# Initialize config file
@@ -40,35 +40,37 @@ module LbpPrintCLI
 
 			# Get parameters
 			output_parent =
-				if config["default_params"] && config["default_params"]["output_parent"]
+				if options["output_parent"]
+					options["output_parent"]
+				elsif config["default_params"] && config["default_params"]["output_parent"]
 					config["default_params"]["output_parent"]
 				else
-					options["output_parent"]
+					"examples"
 				end
 
 			package =
-				if package != nil
-					package = package
+				if options["package"]
+					option["package"]
 				elsif config["default_params"] && config["default_params"]["package"]
 					config["default_params"]["package"]
 				else
-					options["package"]
+					"lbp-print-xslt"
 				end
 
 			type =
-				if type != nil
-					type = type
+				if options["type"]
+					options["type"]
 				elsif not Nokogiri::XML(open(File.expand_path("#{filename}.xml"))).xpath("/tei:TEI/tei:text[1]/@type", 'tei' => 'http://www.tei-c.org/ns/1.0').empty?
 					Nokogiri::XML(open(File.expand_path("#{filename}.xml"))).xpath("/tei:TEI/tei:text[1]/@type", 'tei' => 'http://www.tei-c.org/ns/1.0').to_s
 				elsif config["default_params"] && config["default_params"]["type"]
 					config["default_params"]["type"]
 				else
-					options["type"]
+					"critical"
 				end
 
 			schema =
-				if schema != nil
-					schema = schema
+				if options["schema"]
+					options["schema"]
 				elsif not Nokogiri::XML(open(File.expand_path("#{filename}.xml"))).xpath("/tei:TEI/tei:teiHeader[1]/tei:encodingDesc[1]/tei:schemaRef[1]/@n", 'tei' => 'http://www.tei-c.org/ns/1.0').empty?
 					#get schema id, e.g lbp-critical-1.0.0
 					schema_full = Nokogiri::XML(open(File.expand_path("#{filename}.xml"))).xpath("/tei:TEI/tei:teiHeader[1]/tei:encodingDesc[1]/tei:schemaRef[1]/@n", 'tei' => 'http://www.tei-c.org/ns/1.0')
@@ -77,7 +79,7 @@ module LbpPrintCLI
 				elsif config["default_params"] && config["default_params"]["schema"]
 					config["default_params"]["schema"]
 				else
-					options["schema"]
+					"1.0.0"
 				end
 
 			puts "==============================="
@@ -116,7 +118,7 @@ module LbpPrintCLI
 			self.tex_clean(file_full_path)
 
 			# render pdf
-			if options[:p]
+			if options[:pdf_output]
 				Dir.chdir(output_dir + "/#{filename}/")
 				puts "Creating PDF"
 				`pdflatex #{file_full_path}`


### PR DESCRIPTION
@stenskjaer tell me what you think of these changes. 

I prefer the priority ordering of parameters to be a little bit different. I think command line options have first priority, so that if desired, I could even override the settings within an xml source documents. 

For example, imagine, a text says it is validated against 1.0, but I want to test it against a 1.1 stylesheet for backward compatibility. I'm going to want to override the 1.0 designation within the source document itself. 

So I change things about so that the options themselves have no default settings. The script now first checks to see whether or not an option is set. If it is, it uses that value. If not, it will check either the XML document or the YAML file depending on the parameter in question. Finally, it will default to a hard coded value at the end of the conditional. 

I think it works, but we just need to test it against a variety of combination possibilities.
