### PR TITLE
Remove a typo from reference to optional params

### DIFF
--- a/bin/lbp-print
+++ b/bin/lbp-print
@@ -50,7 +50,7 @@ module LbpPrintCLI
 
 			package =
 				if options["package"]
-					option["package"]
+					options["package"]
 				elsif config["default_params"] && config["default_params"]["package"]
 					config["default_params"]["package"]
 				else


### PR DESCRIPTION
This removes a typo that causes the script to throw an error when using the `--package` parameter.
